### PR TITLE
NEW: store last dumped snapshots to the Redis database

### DIFF
--- a/export.py
+++ b/export.py
@@ -71,6 +71,9 @@ def get_row(node):
     return node + height + hostname + geoip
 
 
+MAX_DUMPED_SNAPSHOTS = 500
+
+
 def export_nodes(nodes, timestamp):
     """
     Merges enumerated data for the specified nodes and exports them into
@@ -87,6 +90,8 @@ def export_nodes(nodes, timestamp):
 
     dump = os.path.join(CONF['export_dir'], "{}.json".format(timestamp))
     open(dump, 'w').write(json.dumps(rows, encoding="latin-1"))
+    REDIS_CONN.lpush('dumped_snapshots', timestamp)
+    REDIS_CONN.ltrim('dumped_snapshots', 0, MAX_DUMPED_SNAPSHOTS)
     logging.info("Wrote %s", dump)
 
 


### PR DESCRIPTION
Store dumped snapshots to the Redis db. This can be used instead of the
pub/sub channel to get a list of available snapshots.

The list is trimmed to a fixed maximun number of elements (500 at the
moment).